### PR TITLE
Refactor with extensible-0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog for mixlogue
 
 ## Unreleased changes
+
+- Refactor with extensible-0.6

--- a/package.yaml
+++ b/package.yaml
@@ -47,7 +47,7 @@ default-extensions:
 dependencies:
 - base >= 4.7 && < 5
 - rio >= 0.1.1.0
-- extensible >= 0.4.9
+- extensible >= 0.6
 - aeson
 - blaze-html
 - elm-export

--- a/src/Language/Elm.hs
+++ b/src/Language/Elm.hs
@@ -15,7 +15,7 @@ import           RIO
 
 import           Data.Extensible
 import           Elm
-import           GHC.TypeLits    (KnownSymbol, symbolVal)
+import           GHC.TypeLits    (KnownSymbol)
 
 class ToElmValue a where
   toElmValue :: a -> ElmValue
@@ -42,5 +42,5 @@ instance Forall (KeyTargetAre KnownSymbol ElmType) xs => ToElmValue (Record xs) 
       append (Values a1 a2) a3 = Values a1 $ append a2 a3
       append a1 a2             = Values a1 a2
       toElmField k v = ElmField
-        (fromString . symbolVal $ proxyAssocKey k)
+        (stringKeyOf k)
         (elmTypeToElmValue . toElmType $ getField v)

--- a/src/Language/Elm.hs
+++ b/src/Language/Elm.hs
@@ -30,9 +30,9 @@ elmTypeToElmValue (ElmPrimitive prim)  = ElmPrimitiveRef prim
 toElmRecordType :: ToElmValue a => Text -> a -> ElmDatatype
 toElmRecordType name = ElmDatatype name . RecordConstructor name . toElmValue
 
-instance Forall (KeyValue KnownSymbol ElmType) xs => ToElmValue (Record xs) where
+instance Forall (KeyTargetAre KnownSymbol ElmType) xs => ToElmValue (Record xs) where
   toElmValue = hfoldrWithIndexFor
-    (Proxy @ (KeyValue KnownSymbol ElmType))
+    (Proxy @ (KeyTargetAre KnownSymbol ElmType))
     (\k v m -> toElmField k v `append` m)
     ElmEmpty
     where

--- a/src/Mixlogue/Slack/Utils.hs
+++ b/src/Mixlogue/Slack/Utils.hs
@@ -3,15 +3,14 @@ module Mixlogue.Slack.Utils where
 import           RIO
 
 import           Data.Extensible
-import           GHC.TypeLits             (symbolVal)
 import           Network.HTTP.Req
 import           Web.Internal.HttpApiData (ToHttpApiData)
 
 toQueryParam ::
-  Forall (KeyValue KnownSymbol ToQueryParam) xs => Record xs -> Option scheme
+  Forall (KeyTargetAre KnownSymbol ToQueryParam) xs => Record xs -> Option scheme
 toQueryParam =
-  hfoldMapWithIndexFor (Proxy @ (KeyValue KnownSymbol ToQueryParam)) $ \m x ->
-  let k = fromString (symbolVal $ proxyAssocKey m) in k ==: runIdentity (getField x)
+  hfoldMapWithIndexFor (Proxy @ (KeyTargetAre KnownSymbol ToQueryParam)) $ \m x ->
+  stringKeyOf m ==: runIdentity (getField x)
 
 class ToHttpApiData a => ToQueryParam a where
   (==:) :: (QueryParam param, Monoid param) => Text -> a -> param
@@ -41,9 +40,9 @@ instance Optional ([a]) where
 instance Optional a => Optional (Identity a) where
   none = pure none
 
-instance Forall (ValueIs Optional) xs => Optional (Record xs) where
-  none = htabulateFor (Proxy @ (ValueIs Optional)) $ \_ -> Field none
+instance Forall (TargetIs Optional) xs => Optional (Record xs) where
+  none = htabulateFor (Proxy @ (TargetIs Optional)) $ \_ -> Field none
 
-fromNullable :: RecordOf h xs -> Nullable (Field h) :* xs -> RecordOf h xs
+fromNullable :: RecordOf h xs -> xs :& Nullable (Field h) -> RecordOf h xs
 fromNullable def =
   hmapWithIndex $ \m x -> fromMaybe (hlookup m def) (getNullable x)

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,21 +2,16 @@ resolver: lts-13.24
 packages:
 - '.'
 extra-deps:
-- extensible-0.5
+- extensible-0.6
+- membership-0
 - req-2.0.1
 - retry-0.8.0.1
 - github: matsubara0507/mix.hs
-  commit: 2138a7a5a43443040893134f1170ce1643f0d498
+  commit: ff640c5209260dce210fa81292df923940608bb7
   subdirs:
   - mix
   - mix-json-logger
-  sha256: 8dfebec78066521d8f5c521293ca3038dec0a70d20c65e5118342e1c96b85e9d
-  size: 8176
 - github: matsubara0507/fallible
   commit: 4a7d965fc8128640ec750b28f7df49be88448286
-  sha256: d572dddea4d784664177f22a37d5fb88c75bf1eef36a968322e9c510630c199c
-  size: 3882
 - github: matsubara0507/elm-export
   commit: 0a05fecf56f84aa2ad998200a03c7df2a1676c0c
-  sha256: 7ecf44003c8e14530dc2a4f03b35e91ca617f2aaf3d2686d9762bece73fb03e4
-  size: 14805

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@ extra-deps:
 - req-2.0.1
 - retry-0.8.0.1
 - github: matsubara0507/mix.hs
-  commit: ff640c5209260dce210fa81292df923940608bb7
+  commit: c6c303f9ddf4655a42804ee67d512af6d3b14e98
   subdirs:
   - mix
   - mix-json-logger


### PR DESCRIPTION
Rename deprecated function and type.
And remove sha256 and size key in stack.yaml for stack-2.1.3.